### PR TITLE
Trusted Global Unicast Address

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/richardpiazza/SessionPlus.git", .upToNextMajor(from: "2.2.0")),
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMajor(from: "1.2.2")),
+        .package(url: "https://github.com/johnsundell/ShellOut.git", from: "2.3.0")
     ],
     targets: [
         .executableTarget(
@@ -29,7 +30,10 @@ let package = Package(
         ),
         .target(
             name: "DynuREST",
-            dependencies: ["SessionPlus"]
+            dependencies: [
+                "SessionPlus",
+                "ShellOut"
+            ]
         ),
         .testTarget(
             name: "DynuRESTTests",

--- a/Sources/DynuREST/IFConfigCommand.swift
+++ b/Sources/DynuREST/IFConfigCommand.swift
@@ -1,0 +1,27 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import SessionPlus
+import ShellOut
+
+/// Uses the `ifconfig` command on the local machine to determine the
+/// IPv6 global unicast address
+public class IFConfigCommand: IPSource {
+    
+    public static var shared: IFConfigCommand = .init()
+    
+    private init() {
+    }
+    
+    public func ipAddress() async throws -> IPAddress {
+        let output = try shellOut(to: "ifconfig | grep inet6 | grep -v fe80 | grep secured")
+        let components = output.split(separator: " ")
+        let addresses = components.compactMap { IPAddress.make(from: String($0)) }
+        guard let address = addresses.first else {
+            throw DynuRESTError.format(output)
+        }
+        
+        return address
+    }
+}

--- a/Sources/cli/IPCommand.swift
+++ b/Sources/cli/IPCommand.swift
@@ -18,20 +18,30 @@ struct IPCommand: AsyncParsableCommand {
     }
     
     enum Source: String, ExpressibleByArgument {
-        case ipify
-        case ifconfig
+        case ipifyApi
+        case ifconfigApi
+        case ifconfigCommand
+        
+        @available(*, deprecated, renamed: "ipifyApi")
+        static var ipify: Self { ipifyApi }
+        
+        @available(*, deprecated, renamed: "ifconfigApi")
+        static var ifconfig: Self { ifconfigApi }
     }
     
-    @Argument(help: "Lookup Source ['ipify', 'ifconfig']")
+    @Argument(help: "Lookup Source ['ipify', 'ifconfigApi', 'ifconfigCommand']")
     var source: Source
     
     func run() async throws {
         switch source {
-        case .ipify:
+        case .ipifyApi:
             let address = try await IPIfyClient.shared.ipAddress()
             print(address.description)
-        case .ifconfig:
+        case .ifconfigApi:
             let address = try await IFConfigClient.shared.ipAddress()
+            print(address.description)
+        case .ifconfigCommand:
+            let address = try await IFConfigCommand.shared.ipAddress()
             print(address.description)
         }
     }

--- a/Sources/cli/UpdateCommand.swift
+++ b/Sources/cli/UpdateCommand.swift
@@ -33,6 +33,9 @@ struct UpdateCommand: AsyncParsableCommand {
     @Option(help: "Collection of hostnames to update. (Comma separated.)")
     var hostname: String?
     
+    @Flag(help: "Prefer IPv6 addresses (Trusted Global Unicast first).")
+    var v6: Bool = false
+    
     func run() async throws {
         guard !username.isEmpty && !password.isEmpty else {
             throw ValidationError("Credentials must be supplied")
@@ -40,7 +43,7 @@ struct UpdateCommand: AsyncParsableCommand {
         
         let authorization = Authorization.basic(username: username, password: password)
         
-        let addresses = await DynuIPUpdater.shared.requestIP()
+        let addresses = await DynuIPUpdater.shared.requestIP(preferIPv6: v6)
         guard let address = addresses.first else {
             throw ValidationError("Failed to retrieve IP Address")
         }


### PR DESCRIPTION
IPv6 addresses obtained using a web API will almost never include a routable address to the machine requesting lookup. The 'Trusted GUA' (Global Unicast Address) of the machine is needed in order to correctly route. This adds a new `IPSource` which runs commands on the local machine in order to determine the correct IPv6 address.
